### PR TITLE
Pythonpath and ROS

### DIFF
--- a/cmake.cmake
+++ b/cmake.cmake
@@ -4,7 +4,11 @@ function (_CREATE_GIT_VERSION_FILE)
   FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/messmer_gitversion")
   FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/messmer_gitversion/gitversion")
 
-  SET(ENV{PYTHONPATH} "${DIR_OF_GITVERSION_TOOL}/src")
+  IF(DEFINED ENV{PYTHONPATH})
+      SET(ENV{PYTHONPATH} "${DIR_OF_GITVERSION_TOOL}/src:ENV{PYTHONPATH}")
+  ELSE()
+      SET(ENV{PYTHONPATH} "${DIR_OF_GITVERSION_TOOL}/src")
+  ENDIF()
   EXECUTE_PROCESS(COMMAND /usr/bin/env python -m gitversionbuilder --lang cpp --dir "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/messmer_gitversion/gitversion/version.h"
 		  RESULT_VARIABLE result)
   IF(NOT ${result} EQUAL 0)


### PR DESCRIPTION
Rewrite the CMake Python Path setting. When the Python path is defined, we extend the Python path instead of overwriting it. This allows use in a ROS project because ROS uses some Python utilities as code generators.